### PR TITLE
900x: update the patches and rename them to 500x

### DIFF
--- a/5001-HID-apple-fix-key-translations-where-multiple-quirks.patch
+++ b/5001-HID-apple-fix-key-translations-where-multiple-quirks.patch
@@ -1,7 +1,7 @@
-From c0cc70b325708106c6145ca68591d3131b64bfbe Mon Sep 17 00:00:00 2001
+From 07a714fc9a7ac7d9313816c365a8c2fd7ee9cb81 Mon Sep 17 00:00:00 2001
 From: Kerem Karabay <kekrby@gmail.com>
-Date: Sat, 10 Sep 2022 10:44:39 +0300
-Subject: [PATCH 1/2] HID: apple: fix key translations where multiple quirks
+Date: Sat, 24 Sep 2022 11:45:51 +0300
+Subject: [PATCH v2 1/2] HID: apple: fix key translations where multiple quirks
  attempt to translate the same key and the ones that depend on other
  translations
 
@@ -63,11 +63,11 @@ dedicated escape key and a non-English layout.
 
 Signed-off-by: Kerem Karabay <kekrby@gmail.com>
 ---
- drivers/hid/hid-apple.c | 99 ++++++++++++++++++-----------------------
- 1 file changed, 44 insertions(+), 55 deletions(-)
+ drivers/hid/hid-apple.c | 102 +++++++++++++++++-----------------------
+ 1 file changed, 44 insertions(+), 58 deletions(-)
 
 diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
-index 6970797cdc56..066e8a85daa5 100644
+index 6970797cdc56..e86bbf85b87e 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
 @@ -314,6 +314,7 @@ static const struct apple_key_translation swapped_option_cmd_keys[] = {
@@ -225,6 +225,16 @@ index 6970797cdc56..066e8a85daa5 100644
  	}
  
  	return 0;
+@@ -640,9 +629,6 @@ static void apple_setup_input(struct input_dev *input)
+ 	apple_setup_key_translation(input, apple2021_fn_keys);
+ 	apple_setup_key_translation(input, macbookpro_no_esc_fn_keys);
+ 	apple_setup_key_translation(input, macbookpro_dedicated_esc_fn_keys);
+-
+-	if (swap_fn_leftctrl)
+-		apple_setup_key_translation(input, swapped_fn_leftctrl_keys);
+ }
+ 
+ static int apple_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 -- 
 2.37.2
 

--- a/5002-HID-apple-enable-APPLE_ISO_TILDE_QUIRK-for-the-keybo.patch
+++ b/5002-HID-apple-enable-APPLE_ISO_TILDE_QUIRK-for-the-keybo.patch
@@ -1,7 +1,7 @@
-From 4c653710ac8054c8e9691ebc9cf302d584b2b542 Mon Sep 17 00:00:00 2001
+From 2680cfe2fd7e3f829c2d82cda38d04a9d269ea7f Mon Sep 17 00:00:00 2001
 From: Kerem Karabay <kekrby@gmail.com>
-Date: Sat, 10 Sep 2022 10:44:40 +0300
-Subject: [PATCH 2/2] HID: apple: enable APPLE_ISO_TILDE_QUIRK for the
+Date: Sat, 24 Sep 2022 11:45:53 +0300
+Subject: [PATCH v2 2/2] HID: apple: enable APPLE_ISO_TILDE_QUIRK for the
  keyboards of Macs with the T2 chip
 
 The iso_layout parameter must be manually set to get the driver to
@@ -19,10 +19,10 @@ Signed-off-by: Kerem Karabay <kekrby@gmail.com>
  1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
-index 066e8a85daa5..df994baf547d 100644
+index e86bbf85b87e..c671ce94671c 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
-@@ -1000,21 +1000,21 @@ static const struct hid_device_id apple_devices[] = {
+@@ -997,21 +997,21 @@ static const struct hid_device_id apple_devices[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
  		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -57,6 +57,10 @@ source=(
   # T2 USB Touchpad support
   4001-Input-bcm5974-Add-support-for-the-T2-Macs.patch
 
+  # Keyboard Layout fixes
+  5001-HID-apple-fix-key-translations-where-multiple-quirks.patch
+  5002-HID-apple-enable-APPLE_ISO_TILDE_QUIRK-for-the-keybo.patch
+
   # Hack for i915 overscan issues
   7001-drm-i915-fbdev-Discard-BIOS-framebuffers-exceeding-h.patch
 
@@ -67,10 +71,6 @@ source=(
   # Broadcom BCM4377 BT device support
   # https://github.com/AsahiLinux/linux/commits/bluetooth-wip
   8002-asahilinux-hci_bcm4377-patchset.patch
-
-  # Keyboard Layout fixes
-  9001-HID-apple-fix-key-translations-where-multiple-quirks.patch
-  9002-HID-apple-enable-APPLE_ISO_TILDE_QUIRK-for-the-keybo.patch
 )
 validpgpkeys=(
   'ABAF11C65A2970B130ABE3C479BE3E4300411886'  # Linus Torvalds
@@ -279,9 +279,9 @@ sha256sums=('b8bb6019d4255f39196726f9d0f82f76179d1c3d7c6b603431ef04b38201199f'
             '398dec7d54c6122ae2263cd5a6d52353800a1a60fd85e52427c372ea9974a625'
             'd4ca5a01da5468a1d2957b8eb4a819e1b867a3bcd1cd47389d7c9ac9154b5430'
             'b1f19084e9a9843dd8c457c55a8ea8319428428657d5363d35df64fb865a4eae'
+            '19208a936b546e36e889b412461e8f990741fa65c6994306507765f3451c9e64'
+            '4db195e0bda5712e60a78266c1458037063e5debd646b08376c4700a27d4b4ef'
             '9ede98eceb69e9c93e25fdb2c567466963bdd2f81c0ecb9fb9e5107f6142ff26'
             '8662089b720681f25068ab479da00790d4e7b168131ea6867ee8db55279c18e6'
-            '20d6086c639b170c941f272a4958ad3c7fbf506d919024883f5e3e6199dcde56'
-            '7e800fe3ca2805cc7f79f081ddc3baaba3805e94ed06ddba3f6e342eb216941b'
-            'f8f9fe683b5e36f01bdafa4f4253200e2df8a804f3ccd66eb2e1ada0f85165d3')
+            '20d6086c639b170c941f272a4958ad3c7fbf506d919024883f5e3e6199dcde56')
 # vim:set ts=8 sts=2 sw=2 et:


### PR DESCRIPTION
The updated version of the patches fix loading the module with `swap_fn_leftctrl=1`.